### PR TITLE
FEATURE: Make Geocoder configurable and instantiate with object manager

### DIFF
--- a/Classes/Ttree/Map/Service/GeocoderService.php
+++ b/Classes/Ttree/Map/Service/GeocoderService.php
@@ -3,7 +3,6 @@ namespace Ttree\Map\Service;
 
 use Geocoder\Exception\NoResult;
 use Geocoder\Provider\GoogleMaps;
-use Ivory\HttpAdapter\CurlHttpAdapter;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Ttree/Map/Service/GeocoderService.php
+++ b/Classes/Ttree/Map/Service/GeocoderService.php
@@ -16,6 +16,7 @@ class GeocoderService {
 
 	/**
 	 * @var GoogleMaps
+     * @Flow\Inject()
 	 */
 	protected $geocoder;
 
@@ -23,14 +24,6 @@ class GeocoderService {
 	 * @var array
 	 */
 	protected $runtimeCache = [];
-
-	/**
-	 * @return void
-	 */
-	public function initializeObject() {
-		$curl = new CurlHttpAdapter();
-		$this->geocoder = new GoogleMaps($curl);
-	}
 
 	/**
 	 * @param string $address

--- a/Classes/Ttree/Map/Service/GeocoderService.php
+++ b/Classes/Ttree/Map/Service/GeocoderService.php
@@ -14,10 +14,10 @@ use Neos\Flow\Annotations as Flow;
  */
 class GeocoderService {
 
-	/**
-	 * @var GoogleMaps
+    /**
+     * @var GoogleMaps
      * @Flow\Inject()
-	 */
+     */
 	protected $geocoder;
 
 	/**

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,15 @@
+Geocoder\Provider\GoogleMaps:
+  arguments:
+    1:
+      object: 'Ivory\HttpAdapter\CurlHttpAdapter'
+    2:
+      setting: 'Ttree.Map.geocoder.locale'
+    3:
+      setting: 'Ttree.Map.geocoder.region'
+    4:
+      setting: 'Ttree.Map.geocoder.useSSL'
+    5:
+      setting: 'Ttree.Map.geocoder.apiKey'
+
+Ivory\HttpAdapter\CurlHttpAdapter:
+  arguments: ~

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,7 +12,12 @@ Ttree:
   Map:
     apiKey:
       name: "API KEY"
-
+    # Configure GoogleMaps Geocoder
+    geocoder:
+      locale: null
+      region: null
+      useSSL: false
+      apiKey: null
     styles:
       default:
         name: "Default Styles"

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,7 +16,7 @@ Ttree:
     geocoder:
       locale: null
       region: null
-      useSSL: false
+      useSSL: true
       apiKey: null
     styles:
       default:


### PR DESCRIPTION
So you can set up a server-side api key for GoogleMaps Geocoder.

E.g 
``` 
Ttree:
  Map:
    geocoder:
      apiKey: 'SomeApiKey'
      useSSL: true
```