### PR TITLE
Fix node property lat/lng is always string

### DIFF
--- a/Classes/Fusion/ConfigurationImplementation.php
+++ b/Classes/Fusion/ConfigurationImplementation.php
@@ -28,7 +28,7 @@ class ConfigurationImplementation extends TemplateImplementation {
 	 */
 	public function getLongitude() {
 		$longitude = $this->fusionValue('longitude');
-		if (is_float($longitude)) {
+		if (is_numeric($longitude)) {
 			return $longitude;
 		}
 		$coordinates = $this->getCoordinates();
@@ -43,7 +43,7 @@ class ConfigurationImplementation extends TemplateImplementation {
 	 */
 	public function getLatitude() {
 		$latitude = $this->fusionValue('latitude');
-		if (is_float($latitude)) {
+		if (is_numeric($latitude)) {
 			return $latitude;
 		}
 		$coordinates = $this->getCoordinates();


### PR DESCRIPTION
When loading node properties with fusion, the values
latitude and longitude are strings, not float.
Therefore the test using is_float is always false,
you must use is_numeric.