### PR TITLE
BUGFIX: Handle attribute classes as array

### DIFF
--- a/Resources/Private/Fusion/NodeTypes/Map.fusion
+++ b/Resources/Private/Fusion/NodeTypes/Map.fusion
@@ -21,8 +21,10 @@ prototype(Ttree.Map:Map) < prototype(Neos.Neos:Content) {
 		id = ${"ttree-map-" + identifier}
 		data-identifier = ${identifier}
 
-		class = 'ttree-map'
-		class.@process.appendClassUsedByJavascript = ${String.trim(value + ' ttree-map-configuration-js')}
+		class {
+			ttree-map = 'ttree-map'
+		}
+		class.@process.appendClassUsedByJavascript = ${Array.concat(value ,' ttree-map-configuration-js')}
 
 		style = ${"height: " + height + "; width: " + width + ";"}
 


### PR DESCRIPTION
The classes property of `Neos.Fusion:Attributes` is a `Neos.Fusion:DataStructure` now. So string concat doesn't work anymore.